### PR TITLE
Check website search engine visibility

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,8 +28,11 @@ export const metadata: Metadata = {
         alt: "Nimabalo Logo",
       },
     ],
-    locale: "en_US",
+    locale: "uz_UZ",
     type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
   },
   icons: {
     icon: "/favicon.svg",
@@ -39,7 +42,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="uz">
       <head>
         <meta charSet="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -47,11 +50,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <link rel="icon" href="/favicon.ico" sizes="any" />
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
         <link rel="manifest" href="/manifest.json" />
-        <meta property="og:title" content="Nimabalo" />
-        <meta property="og:description" content="Savollaringizga javob toping" />
-        <meta property="og:image" content="/logo.svg" />
-        <meta property="og:url" content="https://nimabalo.uz/" />
-        <meta name="twitter:card" content="summary_large_image" />
         {/* Google Search Console verification - Uncomment and add your verification code */}
         <meta name="google-site-verification" content="j5Lw5f1rbcLiwar3-5KOphlKjESosNJ6SO2cw4dTpMQ" />
       </head>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,6 +33,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Nimabalo - Savollar va Javoblar Platformasi",
     description: "O'zbek tilida savollar bering va javoblar oling. Anonim muhitda fikr almashing.",
+    locale: "uz_UZ",
     type: "website",
     siteName: "Nimabalo",
     url: "https://nimabalo.uz",

--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -30,6 +30,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Savollar Ro'yxati - Nimabalo",
     description: "Nimabalo'dagi barcha savollarni ko'ring va javob bering.",
+    locale: "uz_UZ",
     type: "website",
     siteName: "Nimabalo",
     url: "https://nimabalo.uz/questions",


### PR DESCRIPTION
Set site language and Open Graph locale to Uzbek, and remove duplicate meta tags for improved SEO.

The previous setup had hard-coded Open Graph and Twitter meta tags in the `head` alongside Next.js's metadata API, leading to duplication. This change centralizes metadata management through Next.js and ensures the correct locale is applied consistently.

---
<a href="https://cursor.com/background-agent?bcId=bc-fa740781-04b0-4949-a931-d23f5b05deed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fa740781-04b0-4949-a931-d23f5b05deed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

