### PR TITLE
Add Supabase onboarding/schema, .env example, docs, and minor runtime/log tweaks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Public Supabase project URL
+NEXT_PUBLIC_SUPABASE_URL=
+
+# Public Supabase anon key (safe for browser usage)
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+
+# Server-only Supabase service role key (never expose to client code)
+SUPABASE_SERVICE_ROLE_KEY=
+
+# Public site URL used in metadata/canonical links
+NEXT_PUBLIC_SITE_URL=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ src/
 ├── app/          # Next.js routes and layouts
 ├── components/   # UI components
 ├── lib/          # Helpers, hooks, Supabase client
-└── styles/       # Tailwind and design tokens
+├── styles/       # Tailwind and design tokens
+└── supabase/     # DB schema context and onboarding notes
 ```
 
 ## 🤝 Contributing
@@ -68,8 +69,20 @@ src/
 We welcome learners, dreamers, and curious minds.
 You can help by fixing bugs, improving design, or simply joining discussions.
 
-See our [CONTRIBUTING.md](./CONTRIBUTING)
+See our [CONTRIBUTING.md](./CONTRIBUTING.md)
  for details.
+
+### 🔐 Environment Setup
+
+Create your local environment file from the example template before running the app:
+
+```bash
+cp .env.example .env.local
+```
+
+Then fill in the required Supabase values in `.env.local`.
+
+For database setup and schema context, see [`supabase/README.md`](./supabase/README.md).
 
 ## 🛣️ Roadmap (Work-in-Progress)
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "next start",
     "lint": "next lint",
     "bot": "node bot/index.js",
-    "check-db": "node scripts/check-database.js"
+    "check-db": "node scripts/check-database.js",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@supabase/auth-ui-react": "^0.4.7",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -74,14 +74,18 @@ export const revalidate = 30;
 async function getQuestions(): Promise<Question[]> {
   try {
     // Check if environment variables are available
-    console.log('🔍 Server-side env check:', {
-      url: process.env.NEXT_PUBLIC_SUPABASE_URL ? '✅ SET' : '❌ NOT SET',
-      serviceKey: process.env.SUPABASE_SERVICE_ROLE_KEY ? '✅ SET' : '❌ NOT SET'
-    });
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('🔍 Server-side env check:', {
+        url: process.env.NEXT_PUBLIC_SUPABASE_URL ? '✅ SET' : '❌ NOT SET',
+        serviceKey: process.env.SUPABASE_SERVICE_ROLE_KEY ? '✅ SET' : '❌ NOT SET'
+      });
+    }
     
     if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
-      console.warn('⚠️ Supabase environment variables not available during build, returning empty array');
-      console.warn('⚠️ Make sure .env.local exists and dev server was restarted');
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn('⚠️ Supabase environment variables not available during build, returning empty array');
+        console.warn('⚠️ Make sure .env.local exists and dev server was restarted');
+      }
       return [];
     }
 
@@ -97,7 +101,9 @@ async function getQuestions(): Promise<Question[]> {
       return [];
     }
     
-    console.log(`✅ Fetched ${data?.length || 0} questions from Supabase`);
+    if (process.env.NODE_ENV !== 'production') {
+      console.log(`✅ Fetched ${data?.length || 0} questions from Supabase`);
+    }
     return data || [];
   } catch (err) {
     console.error('❌ Exception fetching questions:', err);

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -1,0 +1,26 @@
+# Supabase schema onboarding
+
+This folder keeps database-related context in the repository so contributors can bootstrap the same schema consistently.
+
+## Files
+
+- `schema.sql`: current baseline schema snapshot used by the app.
+
+## Recommended workflow
+
+For long-term maintenance, prefer **migration-first** changes:
+
+1. Create a new migration (Supabase CLI)
+2. Apply migration to local/dev
+3. Commit migration SQL
+4. Regenerate database types
+
+## Generating TypeScript types (recommended)
+
+If you use Supabase CLI and project linkage:
+
+```bash
+supabase gen types typescript --linked > src/lib/database.types.ts
+```
+
+Then use those types in query helpers/hooks for safer refactors.

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,60 @@
+-- Nimabalo baseline schema (reference)
+--
+-- Source: exported from current Supabase project.
+-- This file is kept in-repo for onboarding and schema visibility.
+--
+-- NOTE:
+-- - This is a baseline snapshot, not an ordered migration history.
+-- - Use Supabase migrations for forward-only changes.
+
+create table if not exists public.profiles (
+  id uuid primary key references auth.users(id),
+  username text unique,
+  full_name text,
+  avatar_url text,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.questions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id),
+  title text not null check (char_length(title) >= 3 and char_length(title) <= 200),
+  body text,
+  created_at timestamptz default now(),
+  same_count integer default 0
+);
+
+create table if not exists public.answers (
+  id uuid primary key default gen_random_uuid(),
+  question_id uuid not null references public.questions(id),
+  user_id uuid not null references auth.users(id),
+  body text not null,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.badges (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references public.profiles(id),
+  badge_type text not null,
+  awarded_at timestamptz default now()
+);
+
+create table if not exists public.referrals (
+  id uuid primary key default gen_random_uuid(),
+  referrer_id uuid references public.profiles(id),
+  referred_id uuid unique references public.profiles(id),
+  created_at timestamptz default now()
+);
+
+create table if not exists public.stars (
+  user_id uuid primary key references public.profiles(id),
+  stars integer not null default 0
+);
+
+create table if not exists public.user_reactions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id),
+  question_id uuid not null references public.questions(id),
+  reaction_type text not null default 'same_question',
+  created_at timestamptz default now()
+);


### PR DESCRIPTION
### Motivation

- Provide a committed example environment file and onboarding docs so contributors can bootstrap a local Supabase-backed dev environment.  
- Keep real secrets out of the repo while making it explicit how to create a local `.env` from the template.  
- Improve developer DX by adding a `typecheck` script and reducing noisy server logs in production.

### Description

- Add `.env.example` with public and server Supabase keys and `NEXT_PUBLIC_SITE_URL`.  
- Update `.gitignore` to allow committing `.env.example` while still ignoring real env files with `.env*`.  
- Add `supabase/schema.sql` baseline schema snapshot and `supabase/README.md` with onboarding and type generation guidance.  
- Update `README.md` to include environment setup instructions and link to the Supabase docs, and adjust project tree comments.  
- Add a `typecheck` script to `package.json` (`tsc --noEmit`).  
- Tweak server-side logging in `src/app/page.tsx` to suppress env/log output in production and only log checks and fetch counts in non-production.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69887e611c60833186664f3adca58558)